### PR TITLE
experimental: Update ollama_functions.py to handle json markdown responses e.g. from Gemma

### DIFF
--- a/libs/experimental/langchain_experimental/llms/ollama_functions.py
+++ b/libs/experimental/langchain_experimental/llms/ollama_functions.py
@@ -315,11 +315,16 @@ class OllamaFunctions(ChatOllama):
         try:
             parsed_chat_result = json.loads(chat_generation_content)
         except json.JSONDecodeError:
-            raise ValueError(
-                f"""'{self.model}' did not respond with valid JSON. 
-                Please try again. 
-                Response: {chat_generation_content}"""
-            )
+            # try to remove the markdown block "```json" and "```" if it exists
+            chat_generation_content = chat_generation_content.replace("```json\n", "").replace("```", "")
+            try:
+                parsed_chat_result = json.loads(chat_generation_content)
+            except json.JSONDecodeError:
+                raise ValueError(
+                    f"""'{self.model}' did not respond with valid JSON. 
+                    Please try again. 
+                    Response: {chat_generation_content}"""
+                )
         called_tool_name = parsed_chat_result["tool"]
         called_tool = next(
             (fn for fn in functions if fn["name"] == called_tool_name), None


### PR DESCRIPTION
Some models (e.g. Gemma) seem to always return a json markdown block instead of just the json result for the function call. With this code it would remove the markdown part in that case and then the function calling works.

So this change makes OllamaFunctions work with Gemma 7B in my test. Maybe you want to integrate it to make it easier for future users. But maybe Gemma will just improve and will directly return the correct function call instead of a json markdown block containing the function call. So this is basically just a workaround for Gemma not responding correctly. I don't know if you want to include such workarounds.